### PR TITLE
two-step simulation: use input files already split by pop and chrom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,77 @@
 # admix-kit_workflow
 
 Workflow to implement
-[admixkit](https://kangchenghou.github.io/admix-kit/) on AnVIL
+[admix-kit](https://kangchenghou.github.io/admix-kit/) on AnVIL
 
-## Build and run locally
+The workflows are written in the Workflow Description Language ([WDL](https://docs.dockstore.org/en/stable/getting-started/getting-started-with-wdl.html)). This GitHub repository contains the Dockerfile, the WDL code, and a JSON file containing inputs to the workflow, both for testing and to serve as an example.
 
-```bash
-docker image build -t admix .
-docker run -it admix bash
-```
+The Dockerfile creates a docker image containing the admix-kit software and all dependencies. It is available on Docker Hub as
+[uwgac/admix-kit](https://hub.docker.com/r/uwgac/admix-kit).
+
+
+## sim_admixed
+
+This workflow uses HAPGEN2 to simulate ancestral populations from reference data, and then simulates `n_gen` generations of admixture.
+
+The user must specify the following inputs:
+
+input | description
+--- | ---
+pgen | Input genotype files for the simulation. These must be provided in a nested array structure with the innermost layer being a set of pgen/psam/pvar files, the middle layer being an array of populations, and the outermost layer an array of chromosomes. This is best illustrated with [an example](https://github.com/UW-GAC/admix-kit_workflow/blob/main/sim_admixed.json).
+admix_prop | Admixture proportions for each population in `pgen`
+build | "hg19" or "hg38"
+n_indiv | Number of individuals to simulate
+n_gen | Number of generations to simulate
+
+The workflow returns the following outputs:
+
+output | description
+--- | ---
+out_pgen | Output pgen files with admixed genotypes. This is an array of pgen/psam/pvar file sets for each chromosome.
+out_lanc | Output local ancestry file for simulated individuals.
+
+
+## run_hapgen
+
+This workflow runs HAPGEN2 alone on a single set of pgen files.
+
+The user must specify the following inputs:
+
+input | description
+--- | ---
+pgen | Input genotype files for the simulation. These must be provided as a set of pgen/psam/pvar files. This is best illustrated with [an example](https://github.com/UW-GAC/admix-kit_workflow/blob/main/run_hapgen.json).
+build | "hg19" or "hg38"
+n_indiv | Number of individuals to simulate
+
+The workflow returns the following outputs:
+
+output | description
+--- | ---
+out_pgen | Output pgen file with simulated genotypes
+out_psam | Output psam file with simulated genotypes
+out_pvar | Output pvar file with simulated genotypes
+
+
+## run_admix
+
+This workflow runs admix_simu alone on an array of pgen files for multiple populations. Unlike the inputs for sim_admixed and run_hapgen, the pgen/psam/pvar files must be provided as separate arrays.
+
+The user must specify the following inputs:
+
+input | description
+--- | ---
+pgen | Array of pgen files, one per population
+psam | Array of psam files, one per population
+pvar | Array of pvar files, one per population
+admix_prop | Admixture proportions for each population in `pgen`
+build | "hg19" or "hg38"
+n_indiv | Number of individuals to simulate
+n_gen | Number of generations to simulate
+
+The workflow returns the following outputs:
+
+output | description
+--- | ---
+out_pgen | Output pgen files with admixed genotypes. This is an array of pgen/psam/pvar file sets for each chromosome.
+out_lanc | Output local ancestry file for simulated individuals.
+

--- a/get_ref.wdl
+++ b/get_ref.wdl
@@ -1,13 +1,11 @@
 version 1.0
 
-import "sim_admixed.wdl" as tasks
-
 workflow get_ref {
     input {
         String build
     }
 
-    call tasks.get_1kg_ref {
+    call get_1kg_ref {
          input: build = build
     }
 
@@ -20,5 +18,28 @@ workflow get_ref {
     meta {
         author: "Stephanie Gogarten"
         email: "sdmorris@uw.edu"
+    }
+}
+
+
+task get_1kg_ref {
+    input {
+        String build
+    }
+
+    command <<<
+        admix get-1kg-ref --dir 1kg-ref-~{build} --build ~{build}
+    >>>
+
+    output {
+        File out_pgen = "1kg-ref-~{build}/pgen/all_chr.pgen"
+        File out_psam = "1kg-ref-~{build}/pgen/all_chr.psam"
+        File out_pvar = "1kg-ref-~{build}/pgen/all_chr.pvar"
+    }
+
+    runtime {
+        docker: "uwgac/admix-kit:0.1.1"
+        memory: "16GB"
+        disks: "local-disk 32 SSD"
     }
 }

--- a/run_admix.json
+++ b/run_admix.json
@@ -1,7 +1,7 @@
 {
-    "run_admix.pgen": "myfile.pgen",
-    "run_admix.psam": "myfile.psam",
-    "run_admix.pvar": "myfile.pvar",
+    "run_admix.pgen": ["PEL.22_hapgen2.pgen", "MXL.22_hapgen2.pgen"],
+    "run_admix.psam": ["PEL.22_hapgen2.psam", "MXL.22_hapgen2.psam"],
+    "run_admix.pvar": ["PEL.22_hapgen2.pvar", "MXL.22_hapgen2.pvar"],
     "run_admix.admix_prop": [0.4, 0.6],
     "run_admix.build": "hg38",
     "run_admix.chrom": 22,

--- a/run_admix.json
+++ b/run_admix.json
@@ -4,7 +4,6 @@
     "run_admix.pvar": ["PEL.22_hapgen2.pvar", "MXL.22_hapgen2.pvar"],
     "run_admix.admix_prop": [0.4, 0.6],
     "run_admix.build": "hg38",
-    "run_admix.chrom": 22,
     "run_admix.n_indiv": 10,
     "run_admix.n_gen": 2
 }

--- a/run_admix.wdl
+++ b/run_admix.wdl
@@ -9,7 +9,6 @@ workflow run_admix {
         Array[File] pvar
         Array[Float] admix_prop
         String build
-        Int chrom
         Int n_indiv
         Int n_gen
     }
@@ -20,15 +19,16 @@ workflow run_admix {
                 pvar = pvar,
                 admix_prop = admix_prop,
                 build = build,
-                chrom = chrom,
                 n_indiv = n_indiv,
                 n_gen = n_gen
     }
 
     output {
-        File out_pgen = admix_simu.out_pgen
-        File out_psam = admix_simu.out_psam
-        File out_pvar = admix_simu.out_pvar
+        Map[String, File] out_pgen = {
+            "pgen": "admix.pgen", 
+            "psam": "admix.psam", 
+            "pvar": "admix.pvar"
+        }
         File out_lanc = admix_simu.out_lanc
     }
 

--- a/run_hapgen.json
+++ b/run_hapgen.json
@@ -1,8 +1,9 @@
 {
-    "run_hapgen.pgen": "myfile.pgen",
-    "run_hapgen.psam": "myfile.psam",
-    "run_hapgen.pvar": "myfile.pvar",
+    "run_hapgen.pgen": {
+        "pgen": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/PEL.22.pgen",
+        "psam": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/PEL.22.psam",
+        "pvar": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/PEL.22.pvar"
+    },
     "run_hapgen.build": "hg38",
-    "run_hapgen.chrom": 22,
     "run_hapgen.n_indiv": 10
 }

--- a/run_hapgen.wdl
+++ b/run_hapgen.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-#import "sim_admixed.wdl" as tasks
+import "sim_admixed.wdl" as tasks
 
 workflow run_hapgen {
     input {
@@ -9,52 +9,20 @@ workflow run_hapgen {
         Int n_indiv
     }
 
-    call hapgen2 {
+    call tasks.hapgen2 {
          input: pgen = pgen,
                 build = build,
                 n_indiv = n_indiv
     }
 
     output {
-        Map[String, File] out_pgen = hapgen2.out_pgen
+        File out_pgen = hapgen2.out_pgen
+        File out_psam = hapgen2.out_psam
+        File out_pvar = hapgen2.out_pvar
     }
 
     meta {
         author: "Stephanie Gogarten"
         email: "sdmorris@uw.edu"
-    }
-}
-
-task hapgen2 {
-    input {
-        Map[String, File] pgen
-        String build
-        Int n_indiv
-    }
-
-    String pfile = basename(pgen["pgen"], ".pgen")
-
-    command <<<
-        ln -s ~{pgen["pgen"]} ~{pfile}.pgen
-        ln -s ~{pgen["psam"]} ~{pfile}.psam
-        ln -s ~{pgen["pvar"]} ~{pfile}.pvar
-        admix hapgen2 \
-            --pfile ~{pfile} \
-            --n-indiv ~{n_indiv} \
-            --out ~{pfile}_hapgen2 \
-            --build ~{build}
-    >>>
-
-    output {
-        Map[String, File] out_pgen = {
-            "pgen": "~{pfile}_hapgen2.pgen", 
-            "psam": "~{pfile}_hapgen2.psam", 
-            "pvar": "~{pfile}_hapgen2.pvar"
-        }
-    }
-
-    runtime {
-        docker: "uwgac/admix-kit:0.1.2"
-        memory: "4GB"
     }
 }

--- a/sim_admixed.json
+++ b/sim_admixed.json
@@ -1,8 +1,32 @@
 {
-    "sim_admixed:pops": ["PEL", "MXL"],
+    "sim_admixed:pgen": [
+        [
+            {
+                "pgen": "PEL_chr21.pgen",
+                "psam": "PEL_chr21.psam",
+                "pvar": "PEL_chr21.pvar"
+            },
+            {
+                "pgen": "MXL_chr21.pgen",
+                "psam": "MXL_chr21.psam",
+                "pvar": "MXL_chr21.pvar"
+            }
+        ],
+        [
+            {
+                "pgen": "PEL_chr22.pgen",
+                "psam": "PEL_chr22.psam",
+                "pvar": "PEL_chr22.pvar"
+            },
+            {
+                "pgen": "MXL_chr22.pgen",
+                "psam": "MXL_chr22.psam",
+                "pvar": "MXL_chr22.pvar"
+            }
+        ]
+    ],
     "sim_admixed:admix_prop": [0.4, 0.6],
     "sim_admixed.build": "hg38",
-    "sim_admixed.chroms": [21, 22],
     "sim_admixed.n_indiv": 10,
     "sim_admixed.n_gen": 2
 }

--- a/sim_admixed.json
+++ b/sim_admixed.json
@@ -1,31 +1,31 @@
 {
-    "sim_admixed:pgen": [
+    "sim_admixed.pgen": [
         [
             {
-                "pgen": "PEL_chr21.pgen",
-                "psam": "PEL_chr21.psam",
-                "pvar": "PEL_chr21.pvar"
+                "pgen": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/PEL.21.pgen",
+                "psam": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/PEL.21.psam",
+                "pvar": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/PEL.21.pvar"
             },
             {
-                "pgen": "MXL_chr21.pgen",
-                "psam": "MXL_chr21.psam",
-                "pvar": "MXL_chr21.pvar"
+                "pgen": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/MXL.21.pgen",
+                "psam": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/MXL.21.psam",
+                "pvar": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/MXL.21.pvar"
             }
         ],
         [
             {
-                "pgen": "PEL_chr22.pgen",
-                "psam": "PEL_chr22.psam",
-                "pvar": "PEL_chr22.pvar"
+                "pgen": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/PEL.22.pgen",
+                "psam": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/PEL.22.psam",
+                "pvar": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/PEL.22.pvar"
             },
             {
-                "pgen": "MXL_chr22.pgen",
-                "psam": "MXL_chr22.psam",
-                "pvar": "MXL_chr22.pvar"
+                "pgen": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/MXL.22.pgen",
+                "psam": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/MXL.22.psam",
+                "pvar": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/PROCESSED/hg38/hm3/MXL.22.pvar"
             }
         ]
     ],
-    "sim_admixed:admix_prop": [0.4, 0.6],
+    "sim_admixed.admix_prop": [0.4, 0.6],
     "sim_admixed.build": "hg38",
     "sim_admixed.n_indiv": 10,
     "sim_admixed.n_gen": 2

--- a/sim_admixed.wdl
+++ b/sim_admixed.wdl
@@ -12,9 +12,7 @@ workflow sim_admixed {
     scatter(chrom in pgen) {
         scatter (pop in chrom) {
             call hapgen2 {
-                input: pgen = pop["pgen"],
-                       psam = pop["psam"],
-                       pvar = pop["pvar"],
+                input: pgen = pop,
                        build = build,
                        n_indiv = n_indiv
             }
@@ -32,9 +30,7 @@ workflow sim_admixed {
     }
 
     output {
-        Array[File] out_pgen = admix_simu.out_pgen
-        Array[File] out_psam = admix_simu.out_psam
-        Array[File] out_pvar = admix_simu.out_pvar
+        Array[Map[String, File]] out_pgen = admix_simu.out_pgen
         Array[File] out_lanc = admix_simu.out_lanc
     }
     
@@ -47,19 +43,17 @@ workflow sim_admixed {
 
 task hapgen2 {
     input {
-        File pgen
-        File psam
-        File pvar
+        Map[String, File] pgen
         String build
         Int n_indiv
     }
 
-    String pfile = basename(pgen, ".pgen")
+    String pfile = basename(pgen["pgen"], ".pgen")
 
     command <<<
-        ln -s ~{pgen} ~{pfile}.pgen
-        ln -s ~{psam} ~{pfile}.psam
-        ln -s ~{pvar} ~{pfile}.pvar
+        ln -s ~{pgen["pgen"]} ~{pfile}.pgen
+        ln -s ~{pgen["psam"]} ~{pfile}.psam
+        ln -s ~{pgen["pvar"]} ~{pfile}.pvar
         admix hapgen2 \
             --pfile ~{pfile} \
             --n-indiv ~{n_indiv} \
@@ -102,9 +96,11 @@ task admix_simu {
     >>>
 
     output {
-        File out_pgen = "admix.pgen"
-        File out_psam = "admix.psam"
-        File out_pvar = "admix.pvar"
+        Map[String, File] out_pgen = {
+            "pgen": "admix.pgen", 
+            "psam": "admix.psam", 
+            "pvar": "admix.pvar"
+        }
         File out_lanc = "admix.lanc"
     }
 

--- a/sim_admixed.wdl
+++ b/sim_admixed.wdl
@@ -51,7 +51,6 @@ task hapgen2 {
         File psam
         File pvar
         String build
-        Int? chrom
         Int n_indiv
     }
 
@@ -62,7 +61,7 @@ task hapgen2 {
         ln -s ~{psam} ~{pfile}.psam
         ln -s ~{pvar} ~{pfile}.pvar
         admix hapgen2 \
-            --pfile ~{pfile} ${if defined(chrom) then "--chrom ${chrom}" else ""} \
+            --pfile ~{pfile} \
             --n-indiv ~{n_indiv} \
             --out ~{pfile}_hapgen2 \
             --build ~{build}

--- a/subset_pop.wdl
+++ b/subset_pop.wdl
@@ -1,7 +1,5 @@
 version 1.0
 
-import "sim_admixed.wdl" as tasks
-
 workflow subset_pop {
     input {
         File pgen
@@ -10,7 +8,7 @@ workflow subset_pop {
         String pop
     }
 
-    call tasks.subset_pop_indiv {
+    call subset_pop_indiv {
          input: pgen = pgen,
                 psam = psam,
                 pvar = pvar,
@@ -26,5 +24,42 @@ workflow subset_pop {
     meta {
         author: "Stephanie Gogarten"
         email: "sdmorris@uw.edu"
+    }
+}
+
+
+task subset_pop_indiv {
+    input {
+        File pgen
+        File psam
+        File pvar
+        String pop
+    }
+
+    String pfile = basename(pgen, ".pgen")
+
+    command <<<
+        ln -s ~{pgen} ~{pfile}.pgen
+        ln -s ~{psam} ~{pfile}.psam
+        ln -s ~{pvar} ~{pfile}.pvar
+        admix subset-pop-indiv \
+            --pfile ~{pfile} \
+            --pop ~{pop} \
+            --out ~{pop}.indiv
+        plink2 --pfile ~{pfile} \
+            --keep ~{pop}.indiv \
+            --make-pgen \
+            --out ~{pfile}_~{pop}
+    >>>
+
+    output {
+        File out_pgen = "~{pfile}_~{pop}.pgen"
+        File out_psam = "~{pfile}_~{pop}.psam"
+        File out_pvar = "~{pfile}_~{pop}.pvar"
+    }
+
+    runtime {
+        docker: "uwgac/admix-kit:0.1.1"
+        memory: "4GB"
     }
 }

--- a/subset_ref.wdl
+++ b/subset_ref.wdl
@@ -1,7 +1,5 @@
 version 1.0
 
-import "sim_admixed.wdl" as tasks
-
 workflow subset_ref {
     input {
         File pgen
@@ -11,7 +9,7 @@ workflow subset_ref {
         Int chrom
     }
 
-    call tasks.subset_hapmap3 {
+    call subset_hapmap3 {
          input: pgen = pgen,
                 psam = psam,
                 pvar = pvar,
@@ -28,5 +26,41 @@ workflow subset_ref {
     meta {
         author: "Stephanie Gogarten"
         email: "sdmorris@uw.edu"
+    }
+}
+
+
+task subset_hapmap3 {
+    input {
+        File pgen
+        File psam
+        File pvar
+        String build
+        Int chrom
+    }
+
+    String pfile = basename(pgen, ".pgen")
+
+    command <<<
+        ln -s ~{pgen} ~{pfile}.pgen
+        ln -s ~{psam} ~{pfile}.psam
+        ln -s ~{pvar} ~{pfile}.pvar
+        admix subset-hapmap3 \
+            --pfile ~{pfile} \
+            --build ~{build} \
+            --chrom ~{chrom} \
+            --out_pfile hm3_chr~{chrom}
+    >>>
+
+    output {
+        File out_pgen = "hm3_chr~{chrom}.pgen"
+        File out_psam = "hm3_chr~{chrom}.psam"
+        File out_pvar = "hm3_chr~{chrom}.pvar"
+    }
+
+    runtime {
+        docker: "uwgac/admix-kit:0.1.1"
+        memory: "32GB"
+        disks: "local-disk 32 SSD"
     }
 }


### PR DESCRIPTION
Code for the no-longer-used tasks get_1kg_ref, subset_hapmap3 and subset_pop_indiv was moved to their individual WDL files. The resulting sim_admixed has only two tasks, hapgen2 and admix_simu. Both tasks can also be run with standalone workflows.